### PR TITLE
Bump wokwi ID to avoid collision.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # empty wokwi project; used to ensure the project is unique
-WOKWI_PROJECT_ID=339800239192932947
+WOKWI_PROJECT_ID=341710255833481812
 
 
 fetch:
@@ -20,7 +20,7 @@ harden:
 	/bin/bash -c "./flow.tcl -overwrite -design /work/src -run_path /work/runs -tag wokwi"
 
 lint:
-	iverilog src/user_module_339800239192932947.v
+	iverilog src/user_module_341710255833481812.v
 
 test:
 	make TOPLEVEL=CodeLUT_339800239192932947 MODULE=src.testCodeLUT -f cocotb.mk sim

--- a/cocotb.mk
+++ b/cocotb.mk
@@ -1,7 +1,7 @@
 # cocotb defines
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
-VERILOG_SOURCES += src/user_module_339800239192932947.v
+VERILOG_SOURCES += src/user_module_341710255833481812.v
 TOPLEVEL = mkAdder
 MODULE = hardware.simulation.sim
 SIM_BUILD = build

--- a/src/user_module_341710255833481812.v
+++ b/src/user_module_341710255833481812.v
@@ -70,7 +70,7 @@ module CodeLUT_339800239192932947(input CLK,  input RST,
 
 endmodule
 
-module user_module_339800239192932947(
+module user_module_341710255833481812(
   input [7:0] io_in,
   output [7:0] io_out
 );


### PR DESCRIPTION
Bump dummy Wokwi ID to 341710255833481812.

Project created by opening the ref design and duplicating it with "save a copy", so ID should be unique.

Closes #3.